### PR TITLE
Add files via upload

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,48 @@
+module github.com/HFO4/cloudreve
+
+go 1.13
+
+require (
+	github.com/DATA-DOG/go-sqlmock v1.3.3
+	github.com/aliyun/aliyun-oss-go-sdk v2.0.5+incompatible
+	github.com/aws/aws-sdk-go v1.31.5
+	github.com/baiyubin/aliyun-sts-go-sdk v0.0.0-20180326062324-cfa1a18b161f // indirect
+	github.com/duo-labs/webauthn v0.0.0-20191119193225-4bf9a0f776d4
+	github.com/fatih/color v1.7.0
+	github.com/gin-contrib/cors v1.3.0
+	github.com/gin-contrib/gzip v0.0.2-0.20200226035851-25bef2ef21e8
+	github.com/gin-contrib/sessions v0.0.1
+	github.com/gin-contrib/static v0.0.0-20191128031702-f81c604d8ac2
+	github.com/gin-gonic/gin v1.5.0
+	github.com/go-ini/ini v1.50.0
+	github.com/go-mail/mail v2.3.1+incompatible
+	github.com/gofrs/uuid v3.2.0+incompatible
+	github.com/gomodule/redigo v2.0.0+incompatible
+	github.com/google/go-querystring v1.0.0
+	github.com/gorilla/websocket v1.4.1
+	github.com/hashicorp/go-version v1.2.0
+	github.com/jinzhu/gorm v1.9.11
+	github.com/juju/ratelimit v1.0.1
+	github.com/mattn/go-colorable v0.1.4 // indirect
+	github.com/mojocn/base64Captcha v0.0.0-20190801020520-752b1cd608b2
+	github.com/nfnt/resize v0.0.0-20180221191011-83c6a9932646
+	github.com/pkg/errors v0.9.1
+	github.com/pquerna/otp v1.2.0
+	github.com/qingwg/payjs v0.0.0-20190928033402-c53dbe16b371
+	github.com/qiniu/api.v7/v7 v7.4.0
+	github.com/rafaeljusto/redigomock v0.0.0-20191117212112-00b2509252a1
+	github.com/rakyll/statik v0.1.7
+	github.com/robfig/cron/v3 v3.0.1
+	github.com/smartwalle/alipay/v3 v3.0.13
+	github.com/smartystreets/goconvey v1.6.4 // indirect
+	github.com/speps/go-hashids v2.0.0+incompatible
+	github.com/stretchr/testify v1.5.1
+	github.com/tencentcloud/tencentcloud-sdk-go v3.0.125+incompatible
+	github.com/tencentyun/cos-go-sdk-v5 v0.0.0-20200120023323-87ff3bc489ac
+	github.com/upyun/go-sdk v2.1.0+incompatible
+	golang.org/x/text v0.3.2
+	gopkg.in/alexcesaro/quotedprintable.v3 v3.0.0-20150716171945-2caba252f4dc // indirect
+	gopkg.in/go-playground/validator.v9 v9.29.1
+	gopkg.in/ini.v1 v1.51.0 // indirect
+	gopkg.in/mail.v2 v2.3.1 // indirect
+)


### PR DESCRIPTION
使用了go mod 管理项目，就不需要非得把项目放到GOPATH指定目录下，你可以在你磁盘的任何位置新建一个项目,包含go.mod文件的目录也被称为模块根，也就是说，go.mod 文件的出现定义了它所在的目录为一个模块。